### PR TITLE
hints: use default font weight

### DIFF
--- a/themes/one-dark-darkened.json
+++ b/themes/one-dark-darkened.json
@@ -219,7 +219,7 @@
           "hint": {
             "color": "#5a6f89ff",
             "font_style": null,
-            "font_weight": 700
+            "font_weight": null
           },
           "keyword": {
             "color": "#b477cfff",


### PR DESCRIPTION
inlay hints had their `font_weight` set to `700` which does not conform to the default `One Dark` theme in Zed. 
This PR removes font weight overrides for inlay hints.